### PR TITLE
fix last symbol cutting off

### DIFF
--- a/main.c
+++ b/main.c
@@ -17,7 +17,7 @@ int main(int argc, char* argv[]) {
 			c = getchar();
 		}
 		len = strlen(str);
-		str[len-1] = '\0';
+		if (str[len - 1] == '\n') str[len-1] = '\0';
 		printf("< %s ", str);
 		free(str);
 	}


### PR DESCRIPTION
If the desired string does not have a new line character, last character would be cut off. Fix this behaviour by adding a condition.